### PR TITLE
fix: Switch to htmd for parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,18 +159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "auto_encoder"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1909575e56fe87516c438b6bf75100b2506200fa22e10cbcb4b18ccf2e4bcc5d"
-dependencies = [
- "chardetng",
- "encoding_rs",
- "memchr",
- "phf 0.11.3",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,17 +385,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chardetng"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
-dependencies = [
- "cfg-if",
- "encoding_rs",
- "memchr",
-]
 
 [[package]]
 name = "chrono"
@@ -695,29 +672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cssparser"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf 0.13.1",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,21 +929,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
-name = "dtoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
-
-[[package]]
-name = "dtoa-short"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
-dependencies = [
- "dtoa",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,21 +1017,6 @@ checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
-]
-
-[[package]]
-name = "fast_html2md"
-version = "0.0.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5543120d4ea72a52c6193a224efd05bdc40be5db9af41fcf7291ce165b4a0e86"
-dependencies = [
- "auto_encoder",
- "futures-util",
- "lazy_static",
- "lol_html",
- "percent-encoding",
- "regex",
- "url",
 ]
 
 [[package]]
@@ -1482,6 +1406,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "htmd"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
+dependencies = [
+ "html5ever",
+ "markup5ever_rcdom",
+ "phf 0.13.1",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -2015,25 +1960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lol_html"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff94cb6aef6ee52afd2c69331e9109906d855e82bd241f3110dfdf6185899ab"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cssparser",
- "encoding_rs",
- "foldhash 0.2.0",
- "hashbrown 0.16.1",
- "memchr",
- "mime",
- "precomputed-hash",
- "selectors",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +1991,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
 dependencies = [
  "unicode-id",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.38.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
 ]
 
 [[package]]
@@ -3387,25 +3336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "selectors"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
-dependencies = [
- "bitflags 2.11.0",
- "cssparser",
- "derive_more",
- "log",
- "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "precomputed-hash",
- "rustc-hash",
- "servo_arc",
- "smallvec",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,15 +3414,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "servo_arc"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
-dependencies = [
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -3649,8 +3570,8 @@ dependencies = [
  "atom_syndication",
  "chrono",
  "downcast-rs",
- "fast_html2md",
  "futures",
+ "htmd",
  "reqwest",
  "rss",
  "serde",
@@ -3912,6 +3833,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4016,6 +3962,16 @@ dependencies = [
  "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -4547,6 +4503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4754,6 +4716,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -5338,6 +5312,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xml5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
+dependencies = [
+ "log",
+ "markup5ever",
+]
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 atom_syndication = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 clap = {version = "4.5", features = ["derive"] }
-fast_html2md = "0.0.48"
+htmd = "0.5"
 futures = "0.3"
 markdown = "1.0"
 resolve-path = "0.1"

--- a/crates/slipstream-cli/src/modes/serve/web/mod.rs
+++ b/crates/slipstream-cli/src/modes/serve/web/mod.rs
@@ -156,7 +156,10 @@ struct MinEntry {
 
 impl MinEntry {
     fn from_entry(value: &slipfeed::Entry, config: &Config) -> Self {
-        let md_parser = pulldown_cmark::Parser::new(value.content());
+        let md_parser = pulldown_cmark::Parser::new_ext(
+            value.content(),
+            pulldown_cmark::Options::all(),
+        );
         let mut content = String::new();
         pulldown_cmark::html::push_html(&mut content, md_parser);
         Self {

--- a/crates/slipstream-feeds/Cargo.toml
+++ b/crates/slipstream-feeds/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-fast_html2md = { workspace = true }
+htmd = { workspace = true }
 futures = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/crates/slipstream-feeds/src/feed/types/mastodon/manual.rs
+++ b/crates/slipstream-feeds/src/feed/types/mastodon/manual.rs
@@ -148,8 +148,10 @@ impl MastodonFeed {
         let mut builder = EntryBuilder::new();
 
         let mut content: String = status.content.clone();
-        let md_content: String =
-            html2md::rewrite_html(&status.content, false).trim().into();
+        let md_content: String = htmd::convert(&status.content)
+            .unwrap_or(status.content.clone())
+            .trim()
+            .to_string();
         if !attr.keep_empty && md_content.is_empty() {
             return None;
         }
@@ -157,7 +159,8 @@ impl MastodonFeed {
         builder.title(format!(
             "{}: \"{}\" ({})",
             &status.account.display_name,
-            html2md::rewrite_html(&status.content, false)
+            htmd::convert(&status.content)
+                .unwrap_or(status.content.clone())
                 .chars()
                 .take(40)
                 .collect::<String>(),
@@ -192,7 +195,7 @@ impl MastodonFeed {
             content = format!("{}<br></br>{}", &content, &card.html);
         }
         builder.source_id(&status.id);
-        builder.content(html2md::rewrite_html(&content, false));
+        builder.content(htmd::convert(&content).unwrap_or(content.clone()));
 
         let mut entry = builder.build();
 

--- a/crates/slipstream-feeds/src/feed/types/standard_syndication.rs
+++ b/crates/slipstream-feeds/src/feed/types/standard_syndication.rs
@@ -101,12 +101,14 @@ impl StandardSyndication {
                     .trim(),
             )
             .content(match atom_entry.summary() {
-                Some(sum) => html2md::rewrite_html(&sum.value, false),
+                Some(sum) => {
+                    htmd::convert(&sum.value).unwrap_or(sum.value.clone())
+                }
                 None => match atom_entry.content() {
-                    Some(content) => html2md::rewrite_html(
-                        content.value().unwrap_or(""),
-                        false,
-                    ),
+                    Some(content) => {
+                        let raw = content.value.clone().unwrap_or("".into());
+                        htmd::convert(&raw).unwrap_or(raw.clone())
+                    }
                     None => "".into(),
                 },
             });
@@ -164,13 +166,13 @@ impl StandardSyndication {
                 ctx.parse_time.clone()
             })
             .author(rss_entry.author().unwrap_or(""))
-            .content(html2md::rewrite_html(
-                match rss_entry.description() {
-                    Some(desc) => desc,
-                    None => rss_entry.content().unwrap_or(""),
-                },
-                false,
-            ));
+            .content(match rss_entry.content() {
+                Some(desc) => htmd::convert(desc).unwrap_or(desc.to_string()),
+                None => {
+                    let raw = rss_entry.description().unwrap_or("");
+                    htmd::convert(raw).unwrap_or(raw.to_string())
+                }
+            });
         if let Some(link) = rss_entry.link() {
             parsed.source(link);
         }


### PR DESCRIPTION
fast_html2md does not work correctly and produces wrong output. Also enable all options to render the parsed markdown correctly